### PR TITLE
Add nbtdoc for vehicles

### DIFF
--- a/minecraft/entity/boat.nbtdoc
+++ b/minecraft/entity/boat.nbtdoc
@@ -1,0 +1,15 @@
+compound Boat extends super::EntityBase {
+	/// The wood type of this boat
+	Type: BoatType
+}
+
+enum(string) BoatType {
+	Oak = "oak",
+	Spruce = "spruce",
+	Birch = "birch",
+	Jungle = "jungle",
+	Acacia = "acacia",
+	DarkOak = "dark_oak"
+}
+
+Boat describes minecraft:entity[minecraft:boat];

--- a/minecraft/entity/minecart/chestminecart.nbtdoc
+++ b/minecraft/entity/minecart/chestminecart.nbtdoc
@@ -1,3 +1,5 @@
+use ::minecraft::util::SlottedItem;
+
 compound ChestMinecart extends super::MinecartBase {
 	/// The loot table that will populate this chest minecart
 	LootTable: id(minecraft:loot_table),

--- a/minecraft/entity/minecart/chestminecart.nbtdoc
+++ b/minecraft/entity/minecart/chestminecart.nbtdoc
@@ -1,0 +1,10 @@
+compound ChestMinecart extends super::MinecartBase {
+	/// The loot table that will populate this chest minecart
+	LootTable: id(minecraft:loot_table),
+	/// The seed of the loot table
+	LootTableSeed: long,
+	/// The items in this chest minecart, with slots from 0 to 26
+	Items: [SlottedItem] @ 0..27
+}
+
+ChestMinecart describes minecraft:entity[minecraft:chest_minecart];

--- a/minecraft/entity/minecart/commandminecart.nbtdoc
+++ b/minecraft/entity/minecart/commandminecart.nbtdoc
@@ -1,0 +1,12 @@
+compound CommandMinecart extends super::MinecartBase {
+	/// The command stored in this command block minecart
+	Command: string,
+	/// The success count of the last command
+	SuccessCount: int,
+	/// The last output of this command block minecart
+	LastOutput: string,
+	/// Whether the command block minecart should track its output
+	TrackOutput: boolean
+}
+
+CommandMinecart describes minecraft:entity[minecraft:command_block_minecart];

--- a/minecraft/entity/minecart/furnaceminecart.nbtdoc
+++ b/minecraft/entity/minecart/furnaceminecart.nbtdoc
@@ -1,0 +1,10 @@
+compound FurnaceMinecart extends super::MinecartBase {
+	/// The acceleration in x axis
+	PushX: double,
+	/// The acceleration in y axis
+	PushY: double,
+	/// The number of ticks until the fuel runs out
+	Fuel: short
+}
+
+FurnaceMinecart describes minecraft:entity[minecraft:furnace_minecart];

--- a/minecraft/entity/minecart/hopperminecart.nbtdoc
+++ b/minecraft/entity/minecart/hopperminecart.nbtdoc
@@ -1,0 +1,14 @@
+compound HopperMinecart extends super::MinecartBase {
+	/// The loot table that will populate this hopper minecart
+	LootTable: id(minecraft:loot_table),
+	/// The seed of the loot table
+	LootTableSeed: long,
+	/// The items in this hopper minecart, with slots from 0 to 4
+	Items: [SlottedItem] @ 0..5,
+	/// The number of ticks until an item can be transfered
+	TransferCooldown: int,
+	/// Whether this hopper minecart should pick up items
+	Enabled: boolean
+}
+
+HopperMinecart describes minecraft:entity[minecraft:hopper_minecart];

--- a/minecraft/entity/minecart/hopperminecart.nbtdoc
+++ b/minecraft/entity/minecart/hopperminecart.nbtdoc
@@ -1,3 +1,5 @@
+use ::minecraft::util::SlottedItem;
+
 compound HopperMinecart extends super::MinecartBase {
 	/// The loot table that will populate this hopper minecart
 	LootTable: id(minecraft:loot_table),

--- a/minecraft/entity/minecart/mod.nbtdoc
+++ b/minecraft/entity/minecart/mod.nbtdoc
@@ -10,7 +10,7 @@ use ::minecraft::util::BlockState;
 compound MinecartBase extends super::EntityBase {
 	/// Whether the minecart should display a custom block in it
 	CustomDisplayTile: boolean,
-	/// The custom block to display in the minecart
+	/// The custom block to display in the minecart  
 	/// Only have effects when `CustomDisplayTile` is true
 	DisplayState: BlockState,
 	/// The offset of the custom block displayed in the minecart

--- a/minecraft/entity/minecart/mod.nbtdoc
+++ b/minecraft/entity/minecart/mod.nbtdoc
@@ -1,0 +1,20 @@
+mod chestminecart;
+mod commandminecart;
+mod furnaceminecart;
+mod hopperminecart;
+mod spawnerminecart;
+mod tntminecart;
+
+use ::minecraft::util::BlockState;
+
+compound MinecartBase extends super::EntityBase {
+	/// Whether the minecart should display a custom block in it
+	CustomDisplayTile: boolean,
+	/// The custom block to display in the minecart
+	/// Only have effects when `CustomDisplayTile` is true
+	DisplayState: BlockState,
+	/// The offset of the custom block displayed in the minecart
+	DisplayOffset: int
+}
+
+MinecartBase describes minecraft:entity[minecraft:minecart];

--- a/minecraft/entity/minecart/spawnerminecart.nbtdoc
+++ b/minecraft/entity/minecart/spawnerminecart.nbtdoc
@@ -1,0 +1,26 @@
+use ::minecraft::entity::AnyEntity;
+use ::minecraft::block::spawner::SpawnPotential;
+
+compound SpawnerMinecart extends super::MinecartBase {
+	/// A list of potential entities to spawn next
+	SpawnPotentials: [SpawnPotential],
+	/// The data for the next mob to spawn  
+	/// Will get overwritten by `SpawnPotentials`
+	SpawnData: AnyEntity,
+	/// The number of entities that will be placed
+	SpawnCount: short,
+	/// The range that the spawned entities will be placed
+	SpawnRange: short,
+	/// The number of ticks until the next spawn
+	Delay: short,
+	/// The minimum random delay for the next spawn
+	MinSpawnDelay: short,
+	/// The maximum random delay for the next spawn
+	MaxSpawnDelay: short,
+	/// The maximum number of entities nearby
+	MaxNearbyEntities: short,
+	/// The radius in blocks that a player has to be within to spawn entities
+	RequiredPlayerRange: short
+}
+
+SpawnerMinecart describes minecraft:entity[minecraft:spawner_minecart];

--- a/minecraft/entity/minecart/tntminecart.nbtdoc
+++ b/minecraft/entity/minecart/tntminecart.nbtdoc
@@ -1,0 +1,6 @@
+compound TntMinecart extends super::MinecartBase {
+	/// The number of ticks until this TNT minecart explodes
+	TNTFuse: int
+}
+
+TntMinecart describes minecraft:entity[minecraft:tnt_minecart];

--- a/minecraft/entity/mod.nbtdoc
+++ b/minecraft/entity/mod.nbtdoc
@@ -12,6 +12,8 @@ mod fireworkrocket;
 mod itemframe;
 mod painting;
 mod fireball;
+mod minecart;
+mod boat;
 
 /// Base NBT for all entities
 compound EntityBase {


### PR DESCRIPTION
@Yurihaia 
Note: the style guidelines say that I should put one spaces inside the brackets of one-line `describes` definitions. However in the actual repository none of them use that style, so I just choose the style which is consistent with other files.