### PR TITLE
Fix type of CanPlaceOn and CanDestroy

### DIFF
--- a/minecraft/item/blockitem.nbtdoc
+++ b/minecraft/item/blockitem.nbtdoc
@@ -1,7 +1,8 @@
 /// An item that can be placed as a block
 compound BlockItem extends super::ItemBase {
-	/// A list of blocks that this block item can be placed on
-	CanPlaceOn: [id(minecraft:block)],
+	/// A list of blocks that this block item can be placed on, 
+	/// using the same format as in /setblock command
+	CanPlaceOn: [string],
 	/// The tags that the block entity that is placed can have
 	BlockEntityTag: minecraft:block[super.id],
 	/// The block states that the placed block will have

--- a/minecraft/item/mod.nbtdoc
+++ b/minecraft/item/mod.nbtdoc
@@ -24,8 +24,9 @@ compound ItemBase {
 	/// Whether the item should be unbreakable
 	/// Only used for tools, armor, etc
 	Unbreakable: boolean,
-	/// A list of the blocks that can be destroyed by this item when holding it in adventure mode
-	CanDestroy: [id(minecraft:block)],
+	/// A list of the blocks that can be destroyed by this item when holding it in adventure mode, 
+	/// using the same format as in /setblock command
+	CanDestroy: [string],
 	/// A tag that describes the custom model an item will take.  
 	/// Gets used by the `custom_model_data` model predicate
 	CustomModelData: int,


### PR DESCRIPTION
Currently `CanPlaceOn` and `CanDestroy` are treated as lists of identities, which means that block IDs with block states and compound tags will be validated as errors.

This PR changes them to lists of strings.