### PR TITLE
Change type of lvl to (short | int)

### DIFF
--- a/minecraft/item/mod.nbtdoc
+++ b/minecraft/item/mod.nbtdoc
@@ -54,7 +54,7 @@ compound Enchantment {
 	/// Which enchantment is being described
 	id: id(minecraft:enchantment),
 	/// Which level the enchantment is
-	lvl: short @ 1..
+	lvl: (short @ 1.. | int @ 1..)
 }
 
 /// A single attribute modifier


### PR DESCRIPTION
In #7 I changed the type of `lvl` from `int` to `short`, which was wrong (sorry...)

According to [Minecraft Wiki](https://minecraft.gamepedia.com/Player.dat_format#General_Tags), 

> Saved as short when created by enchanting tables or loot tables, but read as an int and supports full int range.

So the type of `lvl` should be `short | int`