### PR TITLE
Add Base tag to shield

### DIFF
--- a/minecraft/item/shield.nbtdoc
+++ b/minecraft/item/shield.nbtdoc
@@ -7,6 +7,8 @@ compound Shield extends super::ItemBase {
 }
 
 compound Tag {
+	/// The base color of the shield
+	Base: ColorInt,
 	/// The patterns on the shield
 	Patterns: [Pattern]
 }


### PR DESCRIPTION
The `Base` tag is no longer used for banners since they have different IDs for different colors, however it's still used for shields.

This is a code snippet in 1.16.2-pre2's de-compiled code by using yarn's mappings:

```java
public static DyeColor getColor(ItemStack stack) {
    return DyeColor.byId(stack.getOrCreateSubTag("BlockEntityTag").getInt("Base"));
}
```