### PR TITLE
Fix potion entity's item tag

### DIFF
--- a/minecraft/entity/projectile/throwable.nbtdoc
+++ b/minecraft/entity/projectile/throwable.nbtdoc
@@ -2,7 +2,7 @@ use ::minecraft::util::InventoryItem;
 
 compound Throwable extends super::ProjectileBase {
 	/// The shake the projectile creates
-	shake: byte
+	shake: byte,
 	/// The item representation of the projectile
 	Item: InventoryItem
 }

--- a/minecraft/entity/projectile/throwable.nbtdoc
+++ b/minecraft/entity/projectile/throwable.nbtdoc
@@ -1,6 +1,6 @@
 use ::minecraft::util::InventoryItem;
 
-compound BasicThrowable extends Throwable {
+compound Throwable extends super::ProjectileBase {
 	/// The shake the projectile creates
 	shake: byte
 	/// The item representation of the projectile

--- a/minecraft/entity/projectile/throwable.nbtdoc
+++ b/minecraft/entity/projectile/throwable.nbtdoc
@@ -5,8 +5,6 @@ compound Throwable extends super::ProjectileBase {
 	shake: byte
 	/// The item representation of the projectile
 	Item: InventoryItem
-	/// The UUID of the entity who threw the item
-	Owner: int[] @ 4
 }
 
 Throwable describes minecraft:entity[

--- a/minecraft/entity/projectile/throwable.nbtdoc
+++ b/minecraft/entity/projectile/throwable.nbtdoc
@@ -1,23 +1,18 @@
 use ::minecraft::util::InventoryItem;
 
-compound Throwable extends super::ProjectileBase {
+compound BasicThrowable extends Throwable {
 	/// The shake the projectile creates
 	shake: byte
-}
-
-compound BasicThrowable extends Throwable {
 	/// The item representation of the projectile
 	Item: InventoryItem
+	/// The UUID of the entity who threw the item
+	Owner: int[] @ 4
 }
 
-compound PotionThrowable extends Throwable {
-	/// The item representation of the potion
-	Potion: InventoryItem
-}
-
-BasicThrowable describes minecraft:entity[
+Throwable describes minecraft:entity[
 	minecraft:egg,
 	minecraft:ender_pearl,
 	minecraft:experience_bottle,
-	minecraft:snowball
+	minecraft:snowball,
+	minecraft:potion
 ];


### PR DESCRIPTION
This fixes up throwables a bit.
Potion doesn't need special treatment (anymore?), as the contained Item is not stored in `Potion`, but in `Item`, like everywhere else.

I am not quite sure I understood the format correctly, please be extra careful before merging, as this is the first time I ever work with this format.