### PR TITLE
Fix typo in description of armor stand Pose tag

### DIFF
--- a/minecraft/entity/mob/armorstand.nbtdoc
+++ b/minecraft/entity/mob/armorstand.nbtdoc
@@ -17,7 +17,7 @@ compound ArmorStand extends super::LivingEntity {
 	Small: boolean,
 	/// A bit field of the slots that cannot be used
 	DisabledSlots: int,
-	/// The post of the armor stand
+	/// The pose of the armor stand
 	Pose: Pose
 }
 


### PR DESCRIPTION
Reported on discord MCC #meta here <https://discordapp.com/channels/154777837382008833/734106483104415856/765918483073990708>