### PR TITLE
added tag after getting it added to the wiki

### DIFF
--- a/minecraft/entity/mob/player.nbtdoc
+++ b/minecraft/entity/mob/player.nbtdoc
@@ -8,6 +8,8 @@ compound Player extends super::LivingEntity {
 	Dimension: id(minecraft:dimension),
 	/// The game mode that the player is in
 	playerGameType: Gamemode,
+	/// The previous game mode of the player.
+	previousPlayerGameType: Gamemode,
 	/// The score to display upon death
 	Score: int,
 	/// The hotbar slot the player has selected


### PR DESCRIPTION
Added a tag that was missing from the [player.dat file](https://minecraft.gamepedia.com/Player.dat_format).