### PR TITLE
Change beacon none effect ID to -1

### DIFF
--- a/minecraft/block/beacon.nbtdoc
+++ b/minecraft/block/beacon.nbtdoc
@@ -11,7 +11,7 @@ compound Beacon extends super::BlockEntity {
 
 /// Numerical ids for effects
 enum(int) EffectId {
-	None = 0,
+	None = -1,
 	Speed = 1,
 	Slowness = 2,
 	Haste = 3,


### PR DESCRIPTION
Tested in game.
This was apparently a change made in 1.16.2.
See also https://github.com/Gamemode4Dev/GM4_Datapacks/pull/463