### PR TITLE
Update slime to include size limit of 126

### DIFF
--- a/minecraft/entity/mob/slime.nbtdoc
+++ b/minecraft/entity/mob/slime.nbtdoc
@@ -1,7 +1,7 @@
 compound Slimelike extends super::MobBase {
 	/// The size of the slime  
 	/// 0 is the smallest
-	Size: int,
+	Size: int @ 0..126,
 	/// Whether the slime is on the ground
 	wasOnGround: boolean
 }


### PR DESCRIPTION
Limit added in [21w10a](https://www.minecraft.net/en-us/article/minecraft-snapshot-21w10a) The article mentions the max is 128, but I tested this in game and any value above 126 gets clamped to 126.