### PR TITLE
Add item NBT to ArrowBase, block_state NBT to TNT for 23w43a

### DIFF
--- a/minecraft/entity/mod.nbtdoc
+++ b/minecraft/entity/mod.nbtdoc
@@ -48,7 +48,7 @@ compound EntityBase {
 	UUID: int[] @ 4,
 	/// The JSON text component name
 	CustomName: string,
-	/// Whether the custom name should be visible always
+	/// Whether the custom name should be visible always or only when looked at
 	CustomNameVisible: boolean,
 	/// Whether the entity should make any sound
 	Silent: boolean,

--- a/minecraft/entity/projectile/arrow.nbtdoc
+++ b/minecraft/entity/projectile/arrow.nbtdoc
@@ -23,7 +23,9 @@ compound ArrowBase extends super::ProjectileBase {
 	/// Whether the projectile was shot from a crossbow
 	ShotFromCrossbow: boolean,
 	/// The sound event to play when the projectile hits something
-	SoundEvent: string
+	SoundEvent: string,
+	/// The item that will be picked up when collecting the projectile
+	item: InventoryItem
 }
 
 enum(byte) Pickup {
@@ -51,8 +53,6 @@ compound SpectralArrow extends ArrowBase {
 }
 
 compound Trident extends ArrowBase {
-	/// The trident that was thrown
-	Trident: InventoryItem,
 	/// Whether the trident has damaged an entity already
 	DealtDamage: boolean
 }

--- a/minecraft/entity/tnt.nbtdoc
+++ b/minecraft/entity/tnt.nbtdoc
@@ -1,6 +1,12 @@
+use ::minecraft::util::BlockState;
+
 compound Tnt extends super::EntityBase {
 	/// The number of ticks until this tnt explodes
-	Fuse: short
+	fuse: short,
+	// The block model this entity will be rendered with
+	/// Does display most block entities (eg. Chests, Beds, Furnaces, etc).
+	/// Does not display specially rendered block entities (eg. The bell in a bell block, an end gateway, the book on an enchantment table, a banner, a sign, etc).
+	block_state: BlockState
 }
 
 Tnt describes minecraft:entity[minecraft:tnt];


### PR DESCRIPTION
Added the tag `item` to `ArrowBase` for Arrows, Spectral Arrows, and Tridents. Removed the `Trident` tag from Tridents as it's been replaced by `item`.

Added the `block_state` tag to TNT and renamed `Fuse` to `fuse` (from 23w42a).
Changed the description of CustomNameVisible in `EntityBase` (from 23w41a).